### PR TITLE
First working version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2015, Groupon, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of GROUPON nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Testium: Mocha
+
+Testium integration for [mocha](https://mochajs.org/).
+
+* Minimal footprint, just add one `before` hook
+* Can launch your app, selenium/phantomjs for you
+* Automatically takes screenshots on failure
+
+## Install
+
+```bash
+npm install --save-dev testium-mocha testium-driver-sync
+```
+
+## Usage
+
+```js
+// test/my-test.js
+var browser = require('testium-mocha').browser;
+
+describe('testium-mocha - the basics', function() {
+  before(browser.beforeHook());
+
+  it('can load a page', function() {
+    browser.navigateTo('/index.html');
+  });
+});
+```
+
+Run the above test using `mocha test/my-test.js`.

--- a/lib/screenshot.js
+++ b/lib/screenshot.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var Bluebird = require('bluebird');
+var debug = require('debug')('testium:mocha:screenshot');
+var mkdirp = require('mkdirp');
+
+var writeFile = require('./write-file');
+
+var mkdirpAsync = Bluebird.promisify(mkdirp);
+
+function getScreenshotData(browser, rawData) {
+  if (typeof rawData === 'string') {
+    return rawData;
+  }
+
+  // wd calls it takeScreenshot, webdriver-http-sync calls it getScreenshot
+  return browser.takeScreenshot ? browser.takeScreenshot() : browser.getScreenshot();
+}
+
+function writeScreenshot(rawData, directory, title) {
+  if (!rawData) {
+    return '';
+  }
+
+  var screenshotData =
+    typeof rawData === 'string' ? new Buffer(rawData, 'base64') : rawData;
+
+  var screenshotFile = writeFile(directory, title, screenshotData, 'base64');
+  return '\n[TESTIUM] Saved screenshot ' + screenshotFile;
+}
+
+function takeScreenshot(directory, test, browser) {
+  return mkdirpAsync(directory)
+    .then(function getData() {
+      return getScreenshotData(browser, test.err.screen);
+    })
+    .then(function writeData(screenshotData) {
+      return writeScreenshot(screenshotData, directory, test.fullTitle());
+    })
+    .then(function reportFilename(message) {
+      test.err.message += message;
+    })
+    .catch(function gracefulFailure(error) {
+      /* eslint no-console:0 */
+      console.error('Error grabbing screenshot: %s', error.message);
+    });
+}
+
+function takeScreenshotOnFailure(directory) {
+  var browser = this.browser;
+  var currentTest = this.currentTest;
+
+  if (!this.browser) {
+    debug('Not taking screenshot, no browser available');
+    return null;
+  }
+
+  if (!currentTest || currentTest.state !== 'failed') {
+    return null;
+  }
+
+  return takeScreenshot(directory, currentTest, browser);
+}
+
+module.exports = takeScreenshotOnFailure;

--- a/lib/testium-mocha.js
+++ b/lib/testium-mocha.js
@@ -1,1 +1,106 @@
 'use strict';
+
+var path = require('path');
+
+var debug = require('debug')('testium-mocha');
+var _ = require('lodash');
+var Testium = require('testium-core');
+
+var takeScreenshotOnFailure = require('./screenshot');
+
+var getConfig = Testium.getConfig;
+var getTestium = Testium.getTestium;
+
+var CLOSE_BROWSER = 'closeBrowser';
+var CLOSE_BROWSER_PATTERN = /hook: closeBrowser$/;
+var DEFAULT_TITLE = '"before all" hook';
+var BETTER_TITLE = '"before all" hook: Testium setup hook';
+
+var GlobalBrowser = {};
+
+function isCloseBrowserHook(hook) {
+  return CLOSE_BROWSER_PATTERN.test(hook.title);
+}
+
+function addCloseBrowserHook(suite, testium) {
+  if (suite._afterAll.some(isCloseBrowserHook)) {
+    return;
+  }
+  suite.afterAll(CLOSE_BROWSER, function closeBrowser() {
+    return testium.close();
+  });
+}
+
+function getRootSuite(suite) {
+  return suite.parent ? getRootSuite(suite.parent) : suite;
+}
+
+function injectBrowser(options) {
+  options = _.extend({
+    reuseSession: true,
+  }, options || {});
+
+  return function injectBrowserHook() {
+    var self = this;
+    var runnable = this._runnable;
+
+    if (runnable.title === DEFAULT_TITLE) {
+      runnable.title = BETTER_TITLE;
+    }
+
+    var initialConfig = getConfig();
+
+    var mochaTimeout = +initialConfig.get('mocha.timeout', 20000);
+    var mochaSlow = +initialConfig.get('mocha.slow', 2000);
+
+    function setMochaTimeouts(suite) {
+      suite.timeout(mochaTimeout);
+      suite.slow(mochaSlow);
+    }
+
+    function deepMochaTimeouts(suite) {
+      setMochaTimeouts(suite);
+      suite.suites.forEach(deepMochaTimeouts);
+      suite.tests.forEach(setMochaTimeouts);
+      suite._beforeEach.forEach(setMochaTimeouts);
+      suite._beforeAll.forEach(setMochaTimeouts);
+      suite._afterEach.forEach(setMochaTimeouts);
+      suite._afterAll.forEach(setMochaTimeouts);
+    }
+
+    debug('Overriding mocha timeouts', mochaTimeout, mochaSlow);
+    var parentSuite = runnable.parent;
+    deepMochaTimeouts(parentSuite);
+
+    var initialTimeout = +initialConfig.get('app.timeout', 0) + mochaTimeout;
+    this.timeout(initialTimeout);
+
+    function setupHooks(testium) {
+      /* eslint no-proto:0 */
+      GlobalBrowser.__proto__ = self.browser = testium.browser;
+      var config = testium.config;
+
+      var screenshotDirectory = config.get('screenshotDirectory', null);
+      if (screenshotDirectory) {
+        screenshotDirectory = path.resolve(config.root, screenshotDirectory);
+
+        var afterEachHook = _.partial(takeScreenshotOnFailure, screenshotDirectory);
+        parentSuite.afterEach('takeScreenshotOnFailure', afterEachHook);
+      } else {
+        debug('Screenshots are disabled');
+      }
+
+      var browserScopeSuite =
+        options.reuseSession ? getRootSuite(parentSuite) : parentSuite;
+
+      addCloseBrowserHook(browserScopeSuite, testium);
+    }
+
+    return getTestium(options).then(setupHooks);
+  };
+}
+module.exports = injectBrowser;
+injectBrowser.default = injectBrowser;
+
+GlobalBrowser.beforeHook = injectBrowser;
+injectBrowser.browser = GlobalBrowser;

--- a/lib/write-file.js
+++ b/lib/write-file.js
@@ -7,9 +7,9 @@ var MAX_NAME_LENGTH = 40;
 
 function uniqueFile(file) {
   var testPath = file;
-  var counter = null;
+  var counter = 0;
   while (fs.existsSync(testPath + '.png')) {
-    counter = (counter || 0) + 1;
+    ++counter;
     testPath = file + counter;
   }
 

--- a/lib/write-file.js
+++ b/lib/write-file.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 
 var MAX_NAME_LENGTH = 40;
 
-function uniqueFile(file) {
+function uniqueFilename(file) {
   var testPath = file;
   var counter = 0;
   while (fs.existsSync(testPath + '.png')) {
@@ -16,7 +16,7 @@ function uniqueFile(file) {
   return testPath + '.png';
 }
 
-function getFile(directory, title) {
+function generateFilename(directory, title) {
   var name = title
     // 1. Replace all special characters with `_`
     .replace(/[^\w]/g, '_')
@@ -26,11 +26,11 @@ function getFile(directory, title) {
     .substr(0, MAX_NAME_LENGTH);
 
   var filePath = path.join(directory, name);
-  return uniqueFile(filePath);
+  return uniqueFilename(filePath);
 }
 
 function writeFile(directory, title, data, encoding) {
-  var filename = getFile(directory, title);
+  var filename = generateFilename(directory, title);
   fs.writeFileSync(filename, data, encoding || 'base64');
   return filename;
 }

--- a/lib/write-file.js
+++ b/lib/write-file.js
@@ -3,6 +3,8 @@
 var path = require('path');
 var fs = require('fs');
 
+var MAX_NAME_LENGTH = 40;
+
 function uniqueFile(file) {
   var testPath = file;
   var counter = null;
@@ -15,8 +17,13 @@ function uniqueFile(file) {
 }
 
 function getFile(directory, title) {
-  // Take the test title and remove all special characters; limit to 20 characters
-  var name = title.replace(/[^\w]/g, '_').replace(/_{2,}/g, '_').substr(0, 40);
+  var name = title
+    // 1. Replace all special characters with `_`
+    .replace(/[^\w]/g, '_')
+    // 2. Collapse consecutive underscores
+    .replace(/_{2,}/g, '_')
+    // 3. Apply character limit so filenames don't get out of hand
+    .substr(0, MAX_NAME_LENGTH);
 
   var filePath = path.join(directory, name);
   return uniqueFile(filePath);

--- a/lib/write-file.js
+++ b/lib/write-file.js
@@ -18,11 +18,9 @@ function uniqueFilename(file) {
 
 function generateFilename(directory, title) {
   var name = title
-    // 1. Replace all special characters with `_`
-    .replace(/[^\w]/g, '_')
-    // 2. Collapse consecutive underscores
-    .replace(/_{2,}/g, '_')
-    // 3. Apply character limit so filenames don't get out of hand
+    // 1. Replace all special characters sequences with `_`
+    .replace(/[\W_]+/g, '_')
+    // 2. Apply character limit so filenames don't get out of hand
     .substr(0, MAX_NAME_LENGTH);
 
   var filePath = path.join(directory, name);

--- a/lib/write-file.js
+++ b/lib/write-file.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+
+function uniqueFile(file) {
+  var testPath = file;
+  var counter = null;
+  while (fs.existsSync(testPath + '.png')) {
+    counter = (counter || 0) + 1;
+    testPath = file + counter;
+  }
+
+  return testPath + '.png';
+}
+
+function getFile(directory, title) {
+  // Take the test title and remove all special characters; limit to 20 characters
+  var name = title.replace(/[^\w]/g, '_').replace(/_{2,}/g, '_').substr(0, 40);
+
+  var filePath = path.join(directory, name);
+  return uniqueFile(filePath);
+}
+
+function writeFile(directory, title, data, encoding) {
+  var filename = getFile(directory, title);
+  fs.writeFileSync(filename, data, encoding || 'base64');
+  return filename;
+}
+module.exports = writeFile;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "debug": "^2.2.0",
     "lodash": "^3.10.1",
     "mkdirp": "~0.5.1",
-    "testium-core": "testiumjs/testium-core#jk-driver-factory",
-    "testium-driver-sync": "testiumjs/testium-driver-sync#jk-cleanup"
+    "testium-core": "^1.3.0",
+    "testium-driver-sync": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,11 +36,19 @@
     }
   },
   "devDependencies": {
-    "babel-core": "~5.8.25",
-    "babel-eslint": "~4.1.3",
-    "eslint": "~1.7.2",
+    "babel-core": "^5.8.25",
+    "babel-eslint": "^4.1.3",
+    "eslint": "^1.7.2",
     "eslint-config-airbnb": "~0.1.0",
-    "mocha": "~2.3.3",
-    "npub": "~2.2.0"
+    "mocha": "^2.3.3",
+    "npub": "^2.2.0"
+  },
+  "dependencies": {
+    "bluebird": "^2.10.2",
+    "debug": "^2.2.0",
+    "lodash": "^3.10.1",
+    "mkdirp": "~0.5.1",
+    "testium-core": "testiumjs/testium-core#jk-driver-factory",
+    "testium-driver-sync": "testiumjs/testium-driver-sync#jk-cleanup"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
     "eslint": "^1.7.2",
     "eslint-config-airbnb": "~0.1.0",
     "mocha": "^2.3.3",
-    "npub": "^2.2.0"
+    "npub": "^2.2.0",
+    "testium-driver-sync": "^2.0.0"
   },
   "dependencies": {
     "bluebird": "^2.10.2",
     "debug": "^2.2.0",
     "lodash": "^3.10.1",
     "mkdirp": "~0.5.1",
-    "testium-core": "^1.3.0",
-    "testium-driver-sync": "^2.0.0"
+    "testium-core": "^1.3.0"
   }
 }

--- a/test/basic-usage.js
+++ b/test/basic-usage.js
@@ -1,0 +1,11 @@
+import { browser } from '../';
+
+describe('testium-mocha - the basics', () => {
+  before(browser.beforeHook());
+
+  // This awkward construct allows us to run this with -wd and -sync.
+  // For sync we don't need to return the result but it doesn't hurt.
+  it('can load a page', () => {
+    return browser.navigateTo('/index.html');
+  });
+});


### PR DESCRIPTION
Straight port from `testium`. One difference: We also expose an alternate interface which is a awesome (awful?) prototype hack which allows us to side-step the previous need for using `this` and do the following instead:

``` js
import { browser } from 'testium-mocha';

describe('foo', () => {
  before(browser.beforeHook());

  it('does stuff', () => {
    browser.navigateTo('/');
  });
});
```

The old syntax still works:

``` coffee
injectBrowser = require 'testium-mocha'

describe 'foo', ->
  before injectBrowser()

  it 'does stuff', ->
    @browser.navigateTo '/'
```

Depends on:
- https://github.com/testiumjs/testium-core/pull/10
- https://github.com/testiumjs/testium-driver-sync/pull/2

Part of https://github.com/groupon/testium/pull/171
