### PR TITLE
Test screenshot on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 test/tmp
 test/log
+test/screenshot_integration_log

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Mocha integration for testium",
   "main": "lib/testium-mocha.js",
   "scripts": {
-    "test": "eslint lib test && mocha",
+    "test": "eslint lib test && mocha test/integration && mocha",
     "posttest": "npub verify"
   },
   "files": [
@@ -36,12 +36,14 @@
     }
   },
   "devDependencies": {
+    "assertive": "^2.0.2",
     "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.3",
     "eslint": "^1.7.2",
     "eslint-config-airbnb": "~0.1.0",
     "mocha": "^2.3.3",
     "npub": "^2.2.0",
+    "rimraf": "^2.4.3",
     "testium-driver-sync": "^2.0.0"
   },
   "dependencies": {

--- a/test/integration/basic-usage.js
+++ b/test/integration/basic-usage.js
@@ -1,4 +1,4 @@
-import { browser } from '../';
+import { browser } from '../../';
 
 describe('testium-mocha - the basics', () => {
   before(browser.beforeHook());

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
 --compilers js:babel-core/register
---recursive
 --timeout 20000

--- a/test/screenshot_integration/force_screenshot.test.js
+++ b/test/screenshot_integration/force_screenshot.test.js
@@ -1,0 +1,24 @@
+import { browser } from '../../';
+import assert from 'assertive';
+
+describe('forced screenshot', () => {
+  before(browser.beforeHook());
+
+  it('my test', () => {
+    this.browser.navigateTo('/');
+    // This is supposed to be failing, the real status code is 200
+    assert.equal('statuscode', 418, browser.getStatusCode());
+  });
+
+  it('some !%#(*.>:; sPecial  chars', () => {
+    browser.navigateTo('/');
+    // Supposed to be failing as well, actual text is "only one here"
+    browser.assert.elementHasText('.only', 'not on the page');
+  });
+
+  it('does not fail', () => {
+    // empty test should never fail
+    // This makes sure that when everything is fine we do not take
+    // screenshots
+  });
+});

--- a/test/screenshot_integration/force_screenshot.test.js
+++ b/test/screenshot_integration/force_screenshot.test.js
@@ -10,7 +10,7 @@ describe('forced screenshot', () => {
     assert.equal('statuscode', 418, browser.getStatusCode());
   });
 
-  it('some !%#(*.>:; sPecial  chars', () => {
+  it('some !%#__(*.>:; sPecial  chars', () => {
     browser.navigateTo('/');
     // Supposed to be failing as well, actual text is "only one here"
     browser.assert.elementHasText('.only', 'not on the page');

--- a/test/screenshots.test.js
+++ b/test/screenshots.test.js
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import { execFile } from 'child_process';
+
+import assert from 'assertive';
+import rimraf from 'rimraf';
+import { extend } from 'lodash';
+
+const LOG_DIRECTORY = `${__dirname}/screenshot_integration_log`;
+const SCREENSHOT_DIRECTORY = `${__dirname}/screenshot_integration_log/screenshots`;
+const TEST_FILE = 'test/screenshot_integration/force_screenshot.test.js';
+
+const ENV_OVERRIDES = {
+  testium_logDirectory: LOG_DIRECTORY,
+  testium_screenshotDirectory: SCREENSHOT_DIRECTORY,
+};
+
+describe('screenshots', () => {
+  before(`rm -rf ${LOG_DIRECTORY}`, (done) =>
+    rimraf(LOG_DIRECTORY, done));
+
+  before('run failing test suite', function runFailingSuite(done) {
+    this.timeout(10000);
+    const mocha = execFile('./node_modules/.bin/mocha', [ TEST_FILE ], {
+      env: extend(ENV_OVERRIDES, process.env),
+    }, (err, stdout, stderr) => {
+      try {
+        assert.equal(2, mocha.exitCode);
+        done();
+      } catch (exitCodeError) {
+        /* eslint no-console:0 */
+        console.log('Error: %s\nstdout: %s\nstderr: %s',
+          err.stack, stdout, stderr);
+        done(exitCodeError);
+      }
+    });
+  });
+
+  let files;
+  before(`readdir ${SCREENSHOT_DIRECTORY}`, () => {
+    files = fs.readdirSync(SCREENSHOT_DIRECTORY);
+    files.sort();
+  });
+
+  it('creates two screenshots', () => {
+    assert.deepEqual([
+      'forced_screenshot_my_test.png',
+      'forced_screenshot_some_sPecial_chars.png',
+    ], files);
+  });
+});

--- a/test/screenshots.test.js
+++ b/test/screenshots.test.js
@@ -15,7 +15,7 @@ const ENV_OVERRIDES = {
 };
 
 describe('screenshots', () => {
-  before(`rm -rf ${LOG_DIRECTORY}`, (done) =>
+  before(`rm -rf ${LOG_DIRECTORY}`, done =>
     rimraf(LOG_DIRECTORY, done));
 
   before('run failing test suite', function runFailingSuite(done) {


### PR DESCRIPTION
Copied the file(s) from testium & translated to javascript.
- `test/integration`: Tests that launch an app and successfully run against it
- `test/*.js`: Tests that potentially spawn mocha and should not run in the same process as `test/integration` (because of port conflicts)
- `test/screenshot_integration`: A failing test suite to test screenshot taking
