### PR TITLE
Regression: reuseSession=false tore down phantom to early

### DIFF
--- a/lib/testium-mocha.js
+++ b/lib/testium-mocha.js
@@ -22,12 +22,17 @@ function isCloseBrowserHook(hook) {
   return CLOSE_BROWSER_PATTERN.test(hook.title);
 }
 
-function addCloseBrowserHook(suite, testium) {
+function addCloseBrowserHook(suite, browser) {
   if (suite._afterAll.some(isCloseBrowserHook)) {
     return;
   }
   suite.afterAll(CLOSE_BROWSER, function closeBrowser() {
-    return testium.close();
+    if (typeof browser.quit === 'function') {
+      // wd API, hopefully also future testium-driver-sync versions
+      return browser.quit();
+    }
+    // old sync API
+    return browser.close();
   });
 }
 
@@ -93,7 +98,7 @@ function injectBrowser(options) {
       var browserScopeSuite =
         options.reuseSession ? getRootSuite(parentSuite) : parentSuite;
 
-      addCloseBrowserHook(browserScopeSuite, testium);
+      addCloseBrowserHook(browserScopeSuite, testium.browser);
     }
 
     return getTestium(options).then(setupHooks);

--- a/test/integration/no-reuse.js
+++ b/test/integration/no-reuse.js
@@ -1,0 +1,19 @@
+import { browser } from '../../';
+
+describe('reuseSession = false', () => {
+  describe('first test', () => {
+    before(browser.beforeHook({ reuseSession: false }));
+
+    it('does some stuff', () => browser.navigateTo('/index.html'));
+  });
+
+  describe('second test', () => {
+    before(browser.beforeHook({ reuseSession: false }));
+
+    // Make sure that if the first tried to tear down phantomjs etc.,
+    // it had enough time to do so.
+    before((done) => setTimeout(done, 500));
+
+    it('keeps doing stuff', () => browser.navigateTo('/index.html'));
+  });
+});


### PR DESCRIPTION
With `reuseSession=false` we use a after hook for the current test suite to close the selenium session. This code was incorrectly tearing down all of testium instead of just the session, making the following tests fail.
