### PR TITLE
feat: save page html on failure w/ screenshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ node_modules/
 npm-debug.log
 test/tmp
 test/log
-test/screenshot_integration_log
+test/snapshot_integration_log

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Testium integration for [mocha](https://mochajs.org/).
 
 * Minimal footprint, just add one `before` hook
 * Can launch your app, selenium/phantomjs for you
-* Automatically takes screenshots on failure
+* Automatically takes snapshots of screen & html source on failure
 
 This project is a safe and inclusive place
 for contributors of all kinds.

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -32,7 +32,7 @@
 'use strict';
 
 var Bluebird = require('bluebird');
-var debug = require('debug')('testium:mocha:screenshot');
+var debug = require('debug')('testium:mocha:snapshot');
 var mkdirp = require('mkdirp');
 
 var writeFile = require('./write-file');
@@ -56,33 +56,42 @@ function writeScreenshot(rawData, directory, title) {
   var screenshotData =
     typeof rawData === 'string' ? new Buffer(rawData, 'base64') : rawData;
 
-  var screenshotFile = writeFile(directory, title, screenshotData, 'base64');
+  var screenshotFile =
+    writeFile(directory, title, 'png', screenshotData, 'base64');
   return '\n[TESTIUM] Saved screenshot ' + screenshotFile;
 }
 
-function takeScreenshot(directory, test, browser) {
+function writePageSource(pageSource, directory, title) {
+  var pageSourceFile =
+    writeFile(directory, title, 'html', pageSource, 'utf8');
+  return '\n[TESTIUM] Saved page source ' + pageSourceFile;
+}
+
+function takeSnapshot(directory, test, browser) {
   return mkdirpAsync(directory)
     .then(function getData() {
-      return getScreenshotData(browser, test.err.screen);
+      return Bluebird.all([
+        getScreenshotData(browser, test.err.screen),
+        browser.getPageSource(),
+      ]);
     })
-    .then(function writeData(screenshotData) {
-      return writeScreenshot(screenshotData, directory, test.fullTitle());
-    })
-    .then(function reportFilename(message) {
-      test.err.message += message;
+    .spread(function writeData(screenshotData, pageSource) {
+      var title = test.fullTitle();
+      test.err.message += writeScreenshot(screenshotData, directory, title);
+      test.err.message += writePageSource(pageSource, directory, title);
     })
     .catch(function gracefulFailure(error) {
       /* eslint no-console:0 */
-      console.error('Error grabbing screenshot: %s', error.message);
+      console.error('Error grabbing snapshot: %s', error.message);
     });
 }
 
-function takeScreenshotOnFailure(directory) {
+function takeSnapshotOnFailure(directory) {
   var browser = this.browser;
   var currentTest = this.currentTest;
 
   if (!this.browser) {
-    debug('Not taking screenshot, no browser available');
+    debug('Not taking snapshot, no browser available');
     return null;
   }
 
@@ -90,7 +99,7 @@ function takeScreenshotOnFailure(directory) {
     return null;
   }
 
-  return takeScreenshot(directory, currentTest, browser);
+  return takeSnapshot(directory, currentTest, browser);
 }
 
-module.exports = takeScreenshotOnFailure;
+module.exports = takeSnapshotOnFailure;

--- a/lib/testium-mocha.js
+++ b/lib/testium-mocha.js
@@ -37,7 +37,7 @@ var debug = require('debug')('testium-mocha');
 var _ = require('lodash');
 var Testium = require('testium-core');
 
-var takeScreenshotOnFailure = require('./screenshot');
+var takeSnapshotOnFailure = require('./snapshot');
 
 var getConfig = Testium.getConfig;
 var getTestium = Testium.getTestium;
@@ -116,14 +116,15 @@ function injectBrowser(options) {
       GlobalBrowser.__proto__ = self.browser = testium.browser;
       var config = testium.config;
 
-      var screenshotDirectory = config.get('screenshotDirectory', null);
-      if (screenshotDirectory) {
-        screenshotDirectory = path.resolve(config.root, screenshotDirectory);
+      var snapshotDirectory = config.get('snapshotDirectory',
+                              config.get('screenshotDirectory', null));
+      if (snapshotDirectory) {
+        snapshotDirectory = path.resolve(config.root, snapshotDirectory);
 
-        var afterEachHook = _.partial(takeScreenshotOnFailure, screenshotDirectory);
-        parentSuite.afterEach('takeScreenshotOnFailure', afterEachHook);
+        var afterEachHook = _.partial(takeSnapshotOnFailure, snapshotDirectory);
+        parentSuite.afterEach('takeSnapshotOnFailure', afterEachHook);
       } else {
-        debug('Screenshots are disabled');
+        debug('Snapshots are disabled');
       }
 
       var browserScopeSuite =

--- a/lib/write-file.js
+++ b/lib/write-file.js
@@ -36,18 +36,18 @@ var fs = require('fs');
 
 var MAX_NAME_LENGTH = 40;
 
-function uniqueFilename(file) {
+function uniqueFilename(file, ext) {
   var testPath = file;
   var counter = 0;
-  while (fs.existsSync(testPath + '.png')) {
+  while (fs.existsSync(testPath + '.' + ext)) {
     ++counter;
     testPath = file + counter;
   }
 
-  return testPath + '.png';
+  return testPath + '.' + ext;
 }
 
-function generateFilename(directory, title) {
+function generateFilename(directory, title, ext) {
   var name = title
     // 1. Replace all special characters sequences with `_`
     .replace(/[\W_]+/g, '_')
@@ -55,11 +55,11 @@ function generateFilename(directory, title) {
     .substr(0, MAX_NAME_LENGTH);
 
   var filePath = path.join(directory, name);
-  return uniqueFilename(filePath);
+  return uniqueFilename(filePath, ext);
 }
 
-function writeFile(directory, title, data, encoding) {
-  var filename = generateFilename(directory, title);
+function writeFile(directory, title, ext, data, encoding) {
+  var filename = generateFilename(directory, title, ext);
   fs.writeFileSync(filename, data, encoding || 'base64');
   return filename;
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "pretest": "eslint lib test",
-    "test": "mocha test/screenshots.test.js && mocha test/integration",
+    "test": "mocha test/snapshots.test.js && mocha test/integration",
     "posttest": "nlm verify"
   },
   "nlm": {

--- a/test/snapshots.failing
+++ b/test/snapshots.failing
@@ -1,7 +1,7 @@
 import { browser } from '../';
 import assert from 'assertive';
 
-describe('forced screenshot', () => {
+describe('forced snapshot', () => {
   before(browser.beforeHook());
 
   it('my test', () => {
@@ -19,6 +19,6 @@ describe('forced screenshot', () => {
   it('does not fail', () => {
     // empty test should never fail
     // This makes sure that when everything is fine we do not take
-    // screenshots
+    // snapshots
   });
 });

--- a/test/snapshots.test.js
+++ b/test/snapshots.test.js
@@ -5,16 +5,16 @@ import assert from 'assertive';
 import rimraf from 'rimraf';
 import { extend } from 'lodash';
 
-const LOG_DIRECTORY = `${__dirname}/screenshot_integration_log`;
-const SCREENSHOT_DIRECTORY = `${__dirname}/screenshot_integration_log/screenshots`;
-const TEST_FILE = 'test/screenshots.failing';
+const LOG_DIRECTORY = `${__dirname}/snapshot_integration_log`;
+const SNAPSHOT_DIRECTORY = `${__dirname}/snapshot_integration_log/snapshots`;
+const TEST_FILE = 'test/snapshots.failing';
 
 const ENV_OVERRIDES = {
   testium_logDirectory: LOG_DIRECTORY,
-  testium_screenshotDirectory: SCREENSHOT_DIRECTORY,
+  testium_snapshotDirectory: SNAPSHOT_DIRECTORY,
 };
 
-describe('screenshots', () => {
+describe('snapshots', () => {
   before(`rm -rf ${LOG_DIRECTORY}`, done =>
     rimraf(LOG_DIRECTORY, done));
 
@@ -36,15 +36,17 @@ describe('screenshots', () => {
   });
 
   let files;
-  before(`readdir ${SCREENSHOT_DIRECTORY}`, () => {
-    files = fs.readdirSync(SCREENSHOT_DIRECTORY);
+  before(`readdir ${SNAPSHOT_DIRECTORY}`, () => {
+    files = fs.readdirSync(SNAPSHOT_DIRECTORY);
     files.sort();
   });
 
-  it('creates two screenshots', () => {
+  it('creates two snapshots', () => {
     assert.deepEqual([
-      'forced_screenshot_my_test.png',
-      'forced_screenshot_some_sPecial_chars.png',
+      'forced_snapshot_my_test.html',
+      'forced_snapshot_my_test.png',
+      'forced_snapshot_some_sPecial_chars.html',
+      'forced_snapshot_some_sPecial_chars.png',
     ], files);
   });
 });


### PR DESCRIPTION
- next to the .png will now be a .html file
- changed the config param from `screenshotDirectory` to `snapshotDirectory` but still respect old name
