### PR TITLE
supply browser.currentTest property

### DIFF
--- a/.testiumrc
+++ b/.testiumrc
@@ -1,0 +1,8 @@
+driver = wd
+launch = true
+
+[app]
+command = node ./node_modules/testium-example-app/server.js
+
+[proxy]
+port = 0

--- a/lib/testium-mocha.js
+++ b/lib/testium-mocha.js
@@ -94,20 +94,27 @@ function injectBrowser(options) {
     const mochaTimeout = +initialConfig.get('mocha.timeout', 20000);
     const mochaSlow = +initialConfig.get('mocha.slow', 2000);
 
-    function setMochaTimeouts(suite) {
+    function setMochaOverrides(suite) {
       suite.timeout(mochaTimeout);
       suite.slow(mochaSlow);
+      const origFn = suite.fn;
+      if (origFn) {
+        suite.fn = function testiumMochaWrapper() {
+          GlobalBrowser.currentTest = suite.fullTitle();
+          return origFn.apply(this, arguments);
+        };
+      }
     }
 
     function deepMochaTimeouts(suite) {
-      setMochaTimeouts(suite);
+      setMochaOverrides(suite);
       suite.suites.forEach(deepMochaTimeouts);
-      suite.tests.forEach(setMochaTimeouts);
+      suite.tests.forEach(setMochaOverrides);
       /* eslint-disable no-underscore-dangle */
-      suite._beforeEach.forEach(setMochaTimeouts);
-      suite._beforeAll.forEach(setMochaTimeouts);
-      suite._afterEach.forEach(setMochaTimeouts);
-      suite._afterAll.forEach(setMochaTimeouts);
+      suite._beforeEach.forEach(setMochaOverrides);
+      suite._beforeAll.forEach(setMochaOverrides);
+      suite._afterEach.forEach(setMochaOverrides);
+      suite._afterAll.forEach(setMochaOverrides);
       /* eslint-enable no-underscore-dangle */
     }
 
@@ -121,6 +128,8 @@ function injectBrowser(options) {
     function setupHooks(testium) {
       GlobalBrowser.__proto__ = self.browser = testium.browser;
       const config = testium.config;
+
+      GlobalBrowser.currentTest = null;
 
       let snapshotDirectory = config.get(
         'snapshotDirectory',

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "nlm": "^3.0.0",
     "prettier": "^1.6.1",
     "rimraf": "^2.4.3",
-    "testium-driver-sync": "^2.0.0"
+    "testium-driver-wd": "^1.9.1",
+    "testium-example-app": "^2.1.1"
   },
   "author": {
     "name": "Groupon",

--- a/test/integration/basic-usage.test.js
+++ b/test/integration/basic-usage.test.js
@@ -5,9 +5,5 @@ const browser = require('../../').browser;
 describe('testium-mocha - the basics', () => {
   before(browser.beforeHook());
 
-  // This awkward construct allows us to run this with -wd and -sync.
-  // For sync we don't need to return the result but it doesn't hurt.
-  it('can load a page', () => {
-    return browser.navigateTo('/index.html');
-  });
+  it('can load a page', () => browser.loadPage('/index.html'));
 });

--- a/test/integration/no-reuse.test.js
+++ b/test/integration/no-reuse.test.js
@@ -6,7 +6,7 @@ describe('reuseSession = false', () => {
   describe('first test', () => {
     before(browser.beforeHook({ reuseSession: false }));
 
-    it('does some stuff', () => browser.navigateTo('/index.html'));
+    it('does some stuff', () => browser.loadPage('/index.html'));
   });
 
   describe('second test', () => {
@@ -16,6 +16,6 @@ describe('reuseSession = false', () => {
     // it had enough time to do so.
     before(done => setTimeout(done, 500));
 
-    it('keeps doing stuff', () => browser.navigateTo('/index.html'));
+    it('keeps doing stuff', () => browser.loadPage('/index.html'));
   });
 });

--- a/test/snapshots.failing
+++ b/test/snapshots.failing
@@ -6,17 +6,15 @@ const assert = require('assertive');
 describe('forced snapshot', () => {
   before(browser.beforeHook());
 
-  it('my test', () => {
-    browser.navigateTo('/');
+  it('my test', () =>
     // This is supposed to be failing, the real status code is 200
-    assert.equal('statuscode', 418, browser.getStatusCode());
-  });
+    browser.loadPage('/', { expectedStatusCode: 418 }));
 
-  it('some !%#__(*.>:; sPecial  chars', () => {
-    browser.navigateTo('/');
+  it('some !%#__(*.>:; sPecial  chars', () =>
     // Supposed to be failing as well, actual text is "only one here"
-    browser.assert.elementHasText('.only', 'not on the page');
-  });
+    browser
+      .loadPage('/')
+      .assertElementHasText('.only', 'not on the page'));
 
   it('does not fail', () => {
     // empty test should never fail

--- a/test/snapshots.test.js
+++ b/test/snapshots.test.js
@@ -34,7 +34,7 @@ describe('snapshots', () => {
         } catch (exitCodeError) {
           console.log(
             'Error: %s\nstdout: %s\nstderr: %s',
-            err.stack,
+            err && err.stack,
             stdout,
             stderr
           );


### PR DESCRIPTION
This wraps all `it()`, `before()`, etc. mocha call's functions with a wrapper which, before run, sets `browser.currentTest` to the full test description.

The idea is that then this value can be passed up the chain, e.g. as a header in https://github.com/testiumjs/testium-driver-wd

I threw in some test fixes while I was at it.