### PR TITLE
set currentTest on testium.browser

### DIFF
--- a/lib/testium-mocha.js
+++ b/lib/testium-mocha.js
@@ -100,7 +100,8 @@ function injectBrowser(options) {
       const origFn = suite.fn;
       if (origFn) {
         suite.fn = function testiumMochaWrapper() {
-          GlobalBrowser.currentTest = suite.fullTitle();
+          if (GlobalBrowser.__proto__ !== Object.prototype)
+            GlobalBrowser.__proto__.currentTest = suite.fullTitle();
           return origFn.apply(this, arguments);
         };
       }
@@ -128,8 +129,6 @@ function injectBrowser(options) {
     function setupHooks(testium) {
       GlobalBrowser.__proto__ = self.browser = testium.browser;
       const config = testium.config;
-
-      GlobalBrowser.currentTest = null;
 
       let snapshotDirectory = config.get(
         'snapshotDirectory',


### PR DESCRIPTION
It's currently set on GlobalBrowser, which isn't directly accessible to
testium-driver-wd

I actually tested this in -driver-wd this time :-)